### PR TITLE
Fix for 'missing ending /' issue

### DIFF
--- a/components/entity.js
+++ b/components/entity.js
@@ -1,13 +1,13 @@
 const getEntityURL = (type, id) => {
   switch (type) {
     case "char":
-      return `https://zkillboard.com/character/${id}`;
+      return `https://zkillboard.com/character/${id}/`;
     case "ally":
-      return `https://zkillboard.com/alliance/${id}`;
+      return `https://zkillboard.com/alliance/${id}/`;
     case "corp":
-      return `https://zkillboard.com/corporation/${id}`;
+      return `https://zkillboard.com/corporation/${id}/`;
     case "ship":
-      return `https://zkillboard.com/character/${id[1]}/shipTypeID/${id[0]}`;
+      return `https://zkillboard.com/character/${id[1]}/shipTypeID/${id[0]}/`;
   }
 };
 


### PR DESCRIPTION
What it says on the tin. A simple fix for the "missing ending /" issue that occurs when clicking on any https://zkillboard.com link  contained in a table row.