### PR TITLE
Fix docker compose ports error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .jj
 compose.override.yml
+.idea

--- a/compose.yml
+++ b/compose.yml
@@ -15,6 +15,8 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.localthreat-api.rule=Host(`api.localthreat.local.crz.li`)"
+    ports:
+      - 5174:3000
     develop:
       watch:
         - # x-initialSync was introduced in v2.29.2
@@ -36,6 +38,8 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.localthreat-client.rule=Host(`localthreat.local.crz.li`)"
+    ports:
+      - 5173:5173
     develop:
       watch:
         - # x-initialSync was introduced in v2.29.2


### PR DESCRIPTION
There was traefik error with ports not exported. It's fixed by explicitly exporting ports in client and api containers