### PR TITLE
Add points per kill data

### DIFF
--- a/client/src/components/Report.tsx
+++ b/client/src/components/Report.tsx
@@ -118,7 +118,7 @@ type Row = {
   alliance?: null | { id: number; name?: string };
   ships?: null | { id: number; name: string }[];
   dangerRatio?: number | null;
-  pointsRatio?: number | null;
+  pointsPerKill?: number | null;
   gangRatio?: number | null;
   killCount?: number | null;
   lossCount?: number | null;
@@ -130,7 +130,7 @@ const comparers = {
   faction: compareEntityName,
   alliance: compareEntityName,
   dangerRatio: compareNumber,
-  pointsRatio: compareNumber,
+  pointsPerKill: compareNumber,
   gangRatio: compareNumber,
   killCount: compareNumber,
   lossCount: compareNumber,
@@ -350,7 +350,7 @@ export function Report({ params }: { params: { reportId: string } }) {
               <Header sorting={[sorting, "gangRatio"]} className="w-24">
                 Group
               </Header>
-              <Header sorting={[sorting, "pointsRatio"]} className="w-24">
+              <Header sorting={[sorting, "pointsPerKill"]} className="w-24">
                 Points/kill
               </Header>
               <Header sorting={[sorting, "killCount"]} className="w-24">
@@ -405,7 +405,7 @@ export function Report({ params }: { params: { reportId: string } }) {
                   <Stat value={row.gangRatio} style="percent" />
                 </Cell>
                 <Cell className="text-center">
-                  <Stat value={row.pointsRatio} />
+                  <Stat value={row.pointsPerKill} />
                 </Cell>
                 <Cell className="text-center">
                   <Stat value={row.killCount} />

--- a/client/src/components/Report.tsx
+++ b/client/src/components/Report.tsx
@@ -118,6 +118,7 @@ type Row = {
   alliance?: null | { id: number; name?: string };
   ships?: null | { id: number; name: string }[];
   dangerRatio?: number | null;
+  pointsRatio?: number | null;
   gangRatio?: number | null;
   killCount?: number | null;
   lossCount?: number | null;
@@ -129,6 +130,7 @@ const comparers = {
   faction: compareEntityName,
   alliance: compareEntityName,
   dangerRatio: compareNumber,
+  pointsRatio: compareNumber,
   gangRatio: compareNumber,
   killCount: compareNumber,
   lossCount: compareNumber,
@@ -348,6 +350,9 @@ export function Report({ params }: { params: { reportId: string } }) {
               <Header sorting={[sorting, "gangRatio"]} className="w-24">
                 Group
               </Header>
+              <Header sorting={[sorting, "pointsRatio"]} className="w-24">
+                Points/kill
+              </Header>
               <Header sorting={[sorting, "killCount"]} className="w-24">
                 K
               </Header>
@@ -398,6 +403,9 @@ export function Report({ params }: { params: { reportId: string } }) {
                 </Cell>
                 <Cell className="text-center">
                   <Stat value={row.gangRatio} style="percent" />
+                </Cell>
+                <Cell className="text-center">
+                  <Stat value={row.pointsRatio} />
                 </Cell>
                 <Cell className="text-center">
                   <Stat value={row.killCount} />

--- a/client/src/lib/zkillboard.ts
+++ b/client/src/lib/zkillboard.ts
@@ -9,6 +9,7 @@ type State = {
     lossCount: number | null;
     dangerRatio: number | null;
     gangRatio: number | null;
+    pointsRatio: number | null;
     ships: Array<{ id: number; name: string }> | null;
   };
 };
@@ -18,6 +19,7 @@ type Data = {
   shipsLost?: number;
   dangerRatio?: number;
   gangRatio?: number;
+  pointsDestroyed?: number;
   topLists?: Array<{
     type: string;
     values: Array<{ id: number; name: string }>;
@@ -63,6 +65,7 @@ export function useZKillboard() {
                 typeof data.gangRatio === "number"
                   ? data.gangRatio / 100
                   : null,
+              pointsRatio: data.pointsDestroyed !== undefined && data.shipsDestroyed !== undefined ?  data.pointsDestroyed / data.shipsDestroyed : null,
               ships:
                 data.topLists
                   ?.find(({ type }) => type === "shipType")

--- a/client/src/lib/zkillboard.ts
+++ b/client/src/lib/zkillboard.ts
@@ -9,7 +9,7 @@ type State = {
     lossCount: number | null;
     dangerRatio: number | null;
     gangRatio: number | null;
-    pointsRatio: number | null;
+    pointsPerKill: number | null;
     ships: Array<{ id: number; name: string }> | null;
   };
 };
@@ -65,7 +65,7 @@ export function useZKillboard() {
                 typeof data.gangRatio === "number"
                   ? data.gangRatio / 100
                   : null,
-              pointsRatio: data.pointsDestroyed !== undefined && data.shipsDestroyed !== undefined ?  data.pointsDestroyed / data.shipsDestroyed : null,
+              pointsPerKill: calcPointsPerKill(data.pointsDestroyed, data.shipsDestroyed),
               ships:
                 data.topLists
                   ?.find(({ type }) => type === "shipType")
@@ -99,4 +99,11 @@ export function useZKillboard() {
   );
 
   return useMemo(() => ({ state, query }), [state, query]);
+}
+
+function calcPointsPerKill(points: number | undefined, ships: number | undefined): number | null {
+  if (points === undefined || !ships) {
+    return null;
+  }
+  return points / ships;
 }


### PR DESCRIPTION
I find it useful stat to see how much points character gets for kill in average.

As soon as group split points per kill, they get low numbers. Solo kills provide more points. But nobody flyes solo or in group everytime. Also, points relates to how hard and expensive a kill was.

In summary, this stat (points per kill) provides combined analysis for character (not perfect but good addition to other numbers).